### PR TITLE
Add unit test for query parser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,21 @@ jobs:
       # we first have to clone the AddOn project, this is a required step
       - name: Clone project
         uses: actions/checkout@v3
+
+      - name: Install Lua
+        run: sudo apt-get update && sudo apt-get install -y lua5.1
         
       - name: Rename .toc file
         run: mv '!dev_MyBags.toc' MyBags.toc
 
       - name: Add .toc file to Git #workaround for the package to accept this file and not ignore it
         run: git add MyBags.toc
+
+      - name: Run tests
+        run: lua tests/Categorizers/query_test.lua
+
+      - name: Remove tests directory
+        run: rm -rf tests
 
       # once cloned, we just run the GitHub Action for the packager project
       - name: Package and release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Agent Instructions
+
+- Place automated tests under the `tests/` directory, mirroring the source tree of the files they cover (e.g., tests for `Categorizers/query.lua` belong in `tests/Categorizers/query_test.lua`).

--- a/Categorizers/query.lua
+++ b/Categorizers/query.lua
@@ -12,13 +12,13 @@ local ValueType = {
     -- ITEM_QUALITY = 4,
 }
 
-function trim(text)
+local function trim(text)
     return text:match("^%s*(.-)%s*$")
 end
 
 local OpEnum = { AND = 1, OR = 2, NOT = 3 };
 
-function prepare(query)
+local function prepare(query)
     query = string.gsub(query, "%(", " ( ")
     query = string.gsub(query, "%)", " ) ")
     query = string.gsub(query, "([%=%!%~%<%>]+)", " %1 ")
@@ -32,7 +32,6 @@ function prepare(query)
     return query;
 end
 
--- -- print(prepare("()and<=(asd)"))
 local function toboolean(text)
     return text == "true" and true or false
 end
@@ -484,31 +483,9 @@ function AddonNS.QueryCategories:OnInitialize()
     end
 end
 
-local function test()
-    local query = "itemType !=4 or itemType != 5 and itemType = 3" -- AND (itemType = 'weapon' AND ilvl >= 20)
-
-    -- local query = " (type = 'weapon' AND level >= 20) OR (name = 'Epic')"
-    local prepareed = prepare(query);
-    print(prepareed)
-    local func = evaluate(prepareed);
-    local testItem = {
-        itemName = "Epic",
-        isCraftingReagent = true,
-        itemType = 3,
-        ilvl = 120
-    }
-    print("Lets go!")
-    print(func(testItem))
-end
-
--- test()
-
 AddonNS.Events:OnInitialize(AddonNS.QueryCategories.OnInitialize)
 
 AddonNS.Categories:RegisterCategorizer("Query", QueryCategorizer, false);
-
-
-
 
 local function categoryRenamed(eventName, fromCategoryName, toCategoryName)
     AddonNS.printDebug("query:", eventName)
@@ -521,3 +498,9 @@ local function categoryDeleted(eventName, categoryName)
 end
 AddonNS.Events:RegisterCustomEvent(AddonNS.Const.Events.CUSTOM_CATEGORY_RENAMED, categoryRenamed)
 AddonNS.Events:RegisterCustomEvent(AddonNS.Const.Events.CUSTOM_CATEGORY_DELETED, categoryDeleted)
+
+AddonNS._Test = AddonNS._Test or {}
+AddonNS._Test.Query = {
+    prepare = prepare,
+    evaluate = evaluate,
+}

--- a/tests/Categorizers/query_test.lua
+++ b/tests/Categorizers/query_test.lua
@@ -1,0 +1,61 @@
+local addonEnv = {
+  Const = { Events = {
+    CATEGORIZER_CATEGORIES_UPDATED = "CATEGORIZER_CATEGORIES_UPDATED",
+    CUSTOM_CATEGORY_RENAMED = "CUSTOM_CATEGORY_RENAMED",
+    CUSTOM_CATEGORY_DELETED = "CUSTOM_CATEGORY_DELETED",
+  }},
+  Events = {
+    OnInitialize = function() end,
+    RegisterCustomEvent = function() end,
+  },
+  Categories = {
+    RegisterCategorizer = function() end,
+  },
+  printDebug = function() end,
+}
+
+local queryChunk = assert(loadfile("Categorizers/query.lua"))
+queryChunk("MyBags", addonEnv)
+
+local Query = addonEnv._Test.Query
+local testItem1 = {
+  itemName = "Epic",
+  isCraftingReagent = true,
+  itemType = 3,
+  ilvl = 120,
+}
+
+local testItem2 = { itemType = 4 }
+
+local testCases = {
+  {
+    name = "matches itemType 3 with spaces",
+    query = "itemType !=4 or itemType != 5 and itemType = 3",
+    item = testItem1,
+    expected = true,
+  },
+  {
+    name = "rejects itemType 4",
+    query = "itemType !=4 or itemType != 5 and itemType = 3",
+    item = testItem2,
+    expected = false,
+  },
+  {
+    name = "parses without spaces",
+    query = "itemType=3",
+    item = testItem1,
+    expected = true,
+  },
+  {
+    name = "accepts uppercase operators",
+    query = "itemType=3 OR itemType=4",
+    item = testItem2,
+    expected = true,
+  },
+}
+
+for _, case in ipairs(testCases) do
+  local compiledQuery = Query.prepare(case.query)
+  local evaluateItem = Query.evaluate(compiledQuery)
+  assert(evaluateItem(case.item) == case.expected, case.name)
+end


### PR DESCRIPTION
## Summary
- move query test to `tests/Categorizers` to mirror source layout and document the convention
- ensure release workflow runs the query test and removes the `tests` directory prior to packaging
- expose query parser internals via `_Test` at end of module and expand test coverage for spacing and uppercase operators

## Testing
- `lua tests/Categorizers/query_test.lua && echo 'passed'`


------
https://chatgpt.com/codex/tasks/task_b_68c0225602908332931dc66d94460cf5