### PR TITLE
Show all matching categories in item tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Some other worth mentioning:
 * All items by default land in Unassigned category.
 * left click category to collapse it
 * searching works as a filter (to be verify whether this is helpful or not)
+* item tooltip lists other matching categories for easier troubleshooting
 
 ## Q&A
 List of questions about things regarding the addon or possible extentions.

--- a/categories.lua
+++ b/categories.lua
@@ -24,6 +24,8 @@ end
 
 function AddonNS.Categories:Categorize(itemID, itemButton)
     local categoryName;
+    local firstCategory = nil;
+    local matchedCategories = {};
     for _, categorizerDef in categorizers:iterate() do
         categoryName = categorizerDef.categorizer:Categorize(itemID, itemButton);
         if categoryName then
@@ -35,8 +37,18 @@ function AddonNS.Categories:Categorize(itemID, itemButton)
                     description = categorizerDef.description
                 };
             end
-            return categories[categoryName];
+            local categoryObj = categories[categoryName];
+            table.insert(matchedCategories, categoryObj);
+            if not firstCategory then
+                firstCategory = categoryObj;
+            end
         end;
+    end
+    if itemButton then
+        itemButton.ItemCategories = matchedCategories;
+    end
+    if firstCategory then
+        return firstCategory;
     end
     return UNASSIGNED_CATEGORY
 end

--- a/main.lua
+++ b/main.lua
@@ -12,15 +12,12 @@ local function addCategoriesToTooltip(tooltip)
     if not owner or not owner.ItemCategories or #owner.ItemCategories == 0 then return end
     GameTooltip_AddBlankLineToTooltip(tooltip);
     local assigned = owner.ItemCategories[1];
-    if assigned and assigned.name then
-        GameTooltip_AddNormalLine(tooltip, "Category: " .. assigned.name);
-    end
-    if #owner.ItemCategories > 1 then
-        local names = {};
-        for i = 2, #owner.ItemCategories do
-            table.insert(names, owner.ItemCategories[i].name);
+
+    if #owner.ItemCategories > 0 then
+        GameTooltip_AddNormalLine(tooltip, "MyBags matched categories: ");
+        for i = 1, #owner.ItemCategories do
+            GameTooltip_AddNormalLine(tooltip, i .. ". " .. owner.ItemCategories[i].name);
         end
-        GameTooltip_AddNormalLine(tooltip, "Also matches: " .. table.concat(names, ", "));
     end
 end
 
@@ -68,7 +65,8 @@ function AddonNS.Events:INVENTORY_SEARCH_UPDATE(event, bagID)
     container:UpdateItemLayout();
 end
 
-AddonNS.Events:RegisterCustomEvent(AddonNS.Const.Events.CATEGORIZER_CATEGORIES_UPDATED, updateOnTokenWatchChangedOnNextFrame);
+AddonNS.Events:RegisterCustomEvent(AddonNS.Const.Events.CATEGORIZER_CATEGORIES_UPDATED,
+updateOnTokenWatchChangedOnNextFrame);
 AddonNS.Events:RegisterCustomEvent(AddonNS.Const.Events.COLLAPSED_CHANGED, updateOnTokenWatchChangedOnNextFrame);
 
 AddonNS.Events:RegisterEvent("INVENTORY_SEARCH_UPDATE");

--- a/main.lua
+++ b/main.lua
@@ -24,7 +24,8 @@ local function addCategoriesToTooltip(tooltip)
     end
 end
 
-GameTooltip:HookScript("OnTooltipSetItem", addCategoriesToTooltip);
+TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, addCategoriesToTooltip)
+
 local freeBagSlots = 10000;
 local lockedUpdates = false;
 function AddonNS.Events:BAG_UPDATE(event, bagID)

--- a/main.lua
+++ b/main.lua
@@ -6,6 +6,25 @@ AddonNS.itemButtonPlaceholder = {}
 
 local container = ContainerFrameCombinedBags;
 AddonNS.container = container;
+
+local function addCategoriesToTooltip(tooltip)
+    local owner = tooltip:GetOwner();
+    if not owner or not owner.ItemCategories or #owner.ItemCategories == 0 then return end
+    GameTooltip_AddBlankLineToTooltip(tooltip);
+    local assigned = owner.ItemCategories[1];
+    if assigned and assigned.name then
+        GameTooltip_AddNormalLine(tooltip, "Category: " .. assigned.name);
+    end
+    if #owner.ItemCategories > 1 then
+        local names = {};
+        for i = 2, #owner.ItemCategories do
+            table.insert(names, owner.ItemCategories[i].name);
+        end
+        GameTooltip_AddNormalLine(tooltip, "Also matches: " .. table.concat(names, ", "));
+    end
+end
+
+GameTooltip:HookScript("OnTooltipSetItem", addCategoriesToTooltip);
 local freeBagSlots = 10000;
 local lockedUpdates = false;
 function AddonNS.Events:BAG_UPDATE(event, bagID)

--- a/tests/categories_test.lua
+++ b/tests/categories_test.lua
@@ -1,0 +1,39 @@
+local addonEnv = {
+  Const = {
+    Events = {
+      CUSTOM_CATEGORY_DELETED = "CUSTOM_CATEGORY_DELETED",
+      CUSTOM_CATEGORY_RENAMED = "CUSTOM_CATEGORY_RENAMED",
+    },
+    UNASSIGNE_CATEGORY_DB_STORAGE_NAME = "UNASSIGNED",
+  },
+  Events = {
+    RegisterCustomEvent = function() end,
+  },
+  CategorShowAlways = {
+    GetAlwaysShownCategories = function() return {} end,
+  },
+  printDebug = function() end,
+}
+
+dofile("utils/orderedMap.lua")
+local categoriesChunk = assert(loadfile("categories.lua"))
+categoriesChunk("MyBags", addonEnv)
+
+local function makeCategorizer(catName)
+  return {
+    Categorize = function(self, itemID)
+      if itemID == 1 then return catName end
+    end,
+  }
+end
+
+addonEnv.Categories:RegisterCategorizer("cat1", makeCategorizer("cat1"), false)
+addonEnv.Categories:RegisterCategorizer("cat2", makeCategorizer("cat2"), false)
+
+local itemButton = {}
+local category = addonEnv.Categories:Categorize(1, itemButton)
+
+assert(category.name == "cat1", "returns first matching category")
+assert(#itemButton.ItemCategories == 2, "stores all matching categories")
+assert(itemButton.ItemCategories[1].name == "cat1", "first category is first in list")
+assert(itemButton.ItemCategories[2].name == "cat2", "second category is second in list")


### PR DESCRIPTION
## Summary
- track every category that matches an item during categorization
- show assigned and alternative matching categories in the item tooltip
- document tooltip behaviour and add a test for tracking category matches

## Testing
- `lua tests/Categorizers/query_test.lua && lua tests/categories_test.lua`


------
https://chatgpt.com/codex/tasks/task_b_68c0944b574c8332b11e5d300b6a9dfe